### PR TITLE
Add a new `A2A` call task

### DIFF
--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -14,6 +14,7 @@
         + [gRPC](#grpc-call)
         + [HTTP](#http-call)
         + [OpenAPI](#openapi-call)
+        + [A2A](#a2a-call)
     - [Do](#do)
     - [Emit](#emit)
     - [For](#for)

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -493,11 +493,11 @@ The [A2A Call](#a2a-call) enables workflows to interact with AI agents described
 | Name | Type | Required | Description|
 |:--|:---:|:---:|:---|
 | method | `string` | `yes` | The A2A JSON-RPC method to send. |
-| agentCard | [`externalResource`](#external-resource) | `yes` | The Agent Card resource that describes the agent to call. |
+| agentCard | [`externalResource`](#external-resource) | `yes` | The AgentCard resource that describes the agent to call. |
 | parameters | `any` | `no` | The parameters for the A2A rpc method. For the `message/send` and `message/stream` methods the parameters `message.messageId` and `message.role` must be automatically set if missing. |
 
 > [!NOTE]
-> The `security` and `securitySchemes` fields of the Agent Card contain authentication requirements and schemes for when communicating with the agent.
+> The `security` and `securitySchemes` fields of the AgentCard contain authentication requirements and schemes for when communicating with the agent.
 
 > [!NOTE]
 > On success the output is the JSON-RPC result. On failure runtimes must raise an error.

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -520,7 +520,7 @@ do:
         method: message/send
         agentCard: https://example.com/.well-known/agent-card.json
         parameters:
-          message: 
+          message:
             parts:
               - kind: text
                 text: Generate the Q1 sales report.

--- a/dsl-reference.md
+++ b/dsl-reference.md
@@ -320,6 +320,7 @@ Serverless Workflow defines several default functions that **MUST** be supported
 - [gRPC](#grpc-call)
 - [HTTP](#http-call)
 - [OpenAPI](#openapi-call)
+- [A2A](#a2a-call)
 
 ##### AsyncAPI Call
 
@@ -481,6 +482,48 @@ do:
         operationId: findPetsByStatus
         parameters:
           status: available
+```
+
+##### A2A Call
+
+The [A2A Call](#a2a-call) enables workflows to interact with AI agents described by [A2A](https://a2a-protocol.org/).
+
+###### Properties
+
+| Name | Type | Required | Description|
+|:--|:---:|:---:|:---|
+| method | `string` | `yes` | The A2A JSON-RPC method to send. |
+| agentCard | [`externalResource`](#external-resource) | `yes` | The Agent Card resource that describes the agent to call. |
+| parameters | `any` | `no` | The parameters for the A2A rpc method. For the `message/send` and `message/stream` methods the parameters `message.messageId` and `message.role` must be automatically set if missing. |
+
+> [!NOTE]
+> The `security` and `securitySchemes` fields of the Agent Card contain authentication requirements and schemes for when communicating with the agent.
+
+> [!NOTE]
+> On success the output is the JSON-RPC result. On failure runtimes must raise an error.
+
+> [!NOTE]
+> For `message/stream` and `tasks/resubscribe` methods the output is a sequentially ordered array of all the result objects.
+
+###### Examples
+
+```yaml
+document:
+  dsl: '1.0.0'
+  namespace: test
+  name: a2a-example
+  version: '0.1.0'
+do:
+  - GenerateReport:
+      call: a2a
+      with:
+        method: message/send
+        agentCard: https://example.com/.well-known/agent-card.json
+        parameters:
+          message: 
+            parts:
+              - kind: text
+                text: Generate the Q1 sales report.
 ```
 
 #### Do

--- a/dsl.md
+++ b/dsl.md
@@ -596,7 +596,7 @@ Serverless Workflow DSL is designed to seamlessly interact with a variety of ser
 - [**gRPC**](dsl-reference.md#grpc-call): Supports Remote Procedure Call (RPC) using gRPC, a high-performance, open-source universal RPC framework. This is suitable for connecting to services that require low-latency and high-throughput communication.
 - [**AsyncAPI**](dsl-reference.md#asyncapi-call): Facilitates interaction with asynchronous messaging protocols. AsyncAPI is designed for event-driven architectures, allowing workflows to publish and subscribe to events.
 - [**OpenAPI**](dsl-reference.md#openapi-call): Enables communication with services that provide OpenAPI specifications, which is useful for defining and consuming RESTful APIs.
-- [**A2A**](dsl-reference.md#a2a-call): Enables seamless communication with AI agents.
+- [**A2A**](dsl-reference.md#a2a-call): Enables interaction with A2A servers (agents described by A2A).
 
 Runtimes **must** raise an error with type `https://serverlessworkflow.io/spec/1.0.0/errors/communication` if and when a problem occurs during a call.
 

--- a/dsl.md
+++ b/dsl.md
@@ -596,6 +596,7 @@ Serverless Workflow DSL is designed to seamlessly interact with a variety of ser
 - [**gRPC**](dsl-reference.md#grpc-call): Supports Remote Procedure Call (RPC) using gRPC, a high-performance, open-source universal RPC framework. This is suitable for connecting to services that require low-latency and high-throughput communication.
 - [**AsyncAPI**](dsl-reference.md#asyncapi-call): Facilitates interaction with asynchronous messaging protocols. AsyncAPI is designed for event-driven architectures, allowing workflows to publish and subscribe to events.
 - [**OpenAPI**](dsl-reference.md#openapi-call): Enables communication with services that provide OpenAPI specifications, which is useful for defining and consuming RESTful APIs.
+- [**A2A**](dsl-reference.md#a2a-call): Enables seamless communication with AI agents.
 
 Runtimes **must** raise an error with type `https://serverlessworkflow.io/spec/1.0.0/errors/communication` if and when a problem occurs during a call.
 

--- a/schema/workflow.yaml
+++ b/schema/workflow.yaml
@@ -430,6 +430,36 @@ $defs:
                 description: Specifies whether redirection status codes (`300–399`) should be treated as errors.
             required: [ document, operationId ]
             unevaluatedProperties: false
+      - title: CallA2A
+        description: Defines the A2A call to perform.
+        $ref: '#/$defs/taskBase'
+        type: object
+        unevaluatedProperties: false
+        required: [ call, with ]
+        properties:
+          call:
+            type: string
+            const: a2a
+          with:
+            type: object
+            title: A2AArguments
+            description: The A2A call arguments.
+            properties:
+              agentCard:
+                $ref: '#/$defs/externalResource'
+                title: WithA2AAgentCard
+                description: The Agent Card that defines the agent to call.
+              method:
+                type: string
+                title: WithA2AMethod
+                description: The A2A method to send.
+              parameters:
+                type: object
+                title: WithA2AParameters
+                description: The parameters object to send with the A2A method.
+                additionalProperties: true
+            required: [ agentCard, method ]
+            unevaluatedProperties: false
       - title: CallFunction
         description: Defines the function call to perform.
         $ref: '#/$defs/taskBase'


### PR DESCRIPTION
<!--
PLEASE READ THIS BEFORE SUBMITTING A PR!

Other than typos, spelling, or formatting problems in our docs, consider first opening an ISSUE or a DISCUSSION. 

Enhancements or bugs in a specification are not always easy to describe at first glance, requiring some discussions with other contributors before reaching a conclusion.

We kindly ask you to consider opening a discussion or an issue using the Github tab menu above. The community will be more than happy to discuss your proposals there.
-->

**Please specify parts of this PR update:**

- [x] Specification
- [x] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Use Cases
- [ ] Community
- [ ] CTK
- [ ] Other

**Discussion or Issue link**:
<!-- Please consider opening a dicussion or issue for bugs or enhancements. You can ignore this field if this is a typo or spelling fix. -->
#1102 

**What this PR does**:
<!-- Brief description of your PR / Short summary of the discussion or issue -->
Adds A2A call task to the specification

**Additional information:**
<!-- Optional -->

***Push Notifications***
A2A push notification currently only support webhooks as a way to send task update notifications. That said external services can convert those webhook invocations into cloud events that the workflow can listen for. Hopefully at some point A2A can support natively or through an extension sending out push notifications as cloud events directly.

***Streaming***
I am suggesting streaming be handled by collecting up all the objects until the stream is complete and returning them as an ordered array. In the future we can add a `foreach` argument similar to AsyncAPI that when set will run a set of tasks for each object received.
